### PR TITLE
Use the base tag instead of the `kss-base-url` rel tag to get the base u...

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.8.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Use the base tag instead of the `kss-base-url` rel tag to get the base url.
+  [phgross]
 
 
 1.8 (2012-10-16)

--- a/ftw/table/browser/jquery.ftwtable.js
+++ b/ftw/table/browser/jquery.ftwtable.js
@@ -96,7 +96,7 @@
     }else{
       params = parseParams();
     }
-    return $('link[rel=kss-base-url]').attr('href') + $o.url + '?' + params;
+    return $('base').attr('href') + $o.url + '?' + params;
     //return $o.url+'?view_name='+tabbedview.prop('view_name');
     //return $o.url+'?show='+methods.param('show')+'&path='+methods.param('path');
   }


### PR DESCRIPTION
In Plone 4.2 the rel tag `kss-base-url` is renamed, so the base url getter doesn't work. 

In my opinion to use the base tag instead of the kks rel-tag would be the better way to  get the base url.

@jone, @maethu : ok?
