### PR TITLE
Adjust javscripts: Use $ instead of deprecated jq.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.8.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Adjust javscripts: Use $ instead of deprecated jq.
+  [phgross]
 
 
 1.8 (2012-10-16)

--- a/ftw/table/browser/ftwtable.extjs.js
+++ b/ftw/table/browser/ftwtable.extjs.js
@@ -35,7 +35,7 @@ Ext.grid.FTWTableGroupingView = Ext.extend(Ext.grid.GroupingView, {
 });
 
 function reset_grid_state() {
-  jq.ajax({
+  $.ajax({
     url: '@@tabbed_view/setgridstate',
     cache: false,
     type: "POST",


### PR DESCRIPTION
The jq function is deprecated, and plone.app.jquery removes the jquery-integration.js in the newest Version, so i replaced all the jq function with $ function.

So that the javascript part works also without the jquery-integration.js
