### PR TITLE
Fixed base url getter, when the url doesn't ends with a slash.

### DIFF
--- a/ftw/table/browser/jquery.ftwtable.js
+++ b/ftw/table/browser/jquery.ftwtable.js
@@ -96,7 +96,13 @@
     }else{
       params = parseParams();
     }
-    return $('base').attr('href') + $o.url + '?' + params;
+
+    var base_url = $('base').attr('href');
+    if (base_url.slice(-1) != '/'){
+      base_url = base_url + '/';
+    }
+
+    return base_url + $o.url + '?' + params;
     //return $o.url+'?view_name='+tabbedview.prop('view_name');
     //return $o.url+'?show='+methods.param('show')+'&path='+methods.param('path');
   }


### PR DESCRIPTION
In some case the url from the base tag, doesn't ends with a slash, and then the composite url is wrong.
Therefore I added a check in the base_url getter, wich add a slash when it's necessary.

@jone: please hava a look!
