### PR TITLE
Fix javascript order in ExtJS profile (this time for real).

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,11 @@ Changelog
 1.8.3 (unreleased)
 ------------------
 
+- Fix javascript order in ExtJS profile (this time for real).
+  Not only does ftwtable.extjs.js need to be loaded after jquery.ftwtable.js,
+  but also jquery.ftwtable.js after ExtJS (collective.js.extjs-resources/js/ext-all.js).
+  [lgraf]
+
 - Fix javascript order in ExtJS profile.
   [jone]
 

--- a/ftw/table/profiles/extjs/jsregistry.xml
+++ b/ftw/table/profiles/extjs/jsregistry.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0"?>
 <object name="portal_javascripts" meta_type="JavaScripts Registry">
     <javascript cacheable="True" compression="safe" cookable="True"
-       enabled="1" expression="" id="++resource++jquery.ftwtable.js" />
+       enabled="1" expression="" id="++resource++jquery.ftwtable.js"
+       insert-after="++resource++collective.js.extjs-resources/js/ext-all.js"/>
    <javascript cacheable="True" compression="safe" cookable="True"
       enabled="1" expression="" id="++resource++ftwtable.extjs.js"
       insert-after="++resource++jquery.ftwtable.js" />


### PR DESCRIPTION
Not only does `ftwtable.extjs.js` need to be loaded after
`jquery.ftwtable.js`, but also `jquery.ftwtable.js` after
ExtJS (`collective.js.extjs-resources/js/ext-all.js`).
