### PR TITLE
Implement "callable" values - implemented in get_value method of TableGe...

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.10 (unreleased)
 -----------------
 
-- Nothing changed yet.
+- Implement "callable" values - implemented in get_value method of TableGenerator.
+  [mathias.leimgruber]
 
 
 1.9 (2013-01-28)

--- a/ftw/table/utils.py
+++ b/ftw/table/utils.py
@@ -202,6 +202,8 @@ class TableGenerator(object):
         value = u''
         if hasattr(content, attr):
             value = getattr(content, attr)
+        if callable(value):
+            value = value()
         elif hasattr(content, '__iter__') and attr in content:
             value = content[attr]
         return transform(content, value)


### PR DESCRIPTION
@jone I was not able to test this feature... imho get_value is called always in html mode.
But if I extended the html rendering tests, it did not work. 
