### PR TITLE
ExtJS style: fix improper layout.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,9 @@ Changelog
 1.12 (unreleased)
 -----------------
 
-- Nothing changed yet.
+- ExtJS style: fix improper layout.
+  Also show dummy column in table body using the same width used in the header.
+  [Julian Infanger]
 
 
 1.11 (2013-05-06)

--- a/ftw/table/browser/extjs/ext-all.css
+++ b/ftw/table/browser/extjs/ext-all.css
@@ -368,6 +368,9 @@
 
 /* @group ugly fixes */
 .x-grid3-td-dummy {
+  width: 5px !important;
+  display: table-cell !important;
+  border: none !important;
   background-color: #FFFFFF;
 }
 /* @end */


### PR DESCRIPTION
@maethu @jone 
Also show dummy column in table body using the same width used in the header.
![bildschirmfoto 2013-05-30 um 07 50 36](https://f.cloud.github.com/assets/157533/583409/30db8b0e-c8ee-11e2-970b-c89016c0dd9c.png)
