### PR TITLE
Support setting "sortable" to False for a column in non-ExtJS mode.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 1.12 (unreleased)
 -----------------
 
+- Support setting "sortable" to false for a column in non-ExtJS mode.
+  [jone]
+
 - HTML style: support "width" of column definition as <col> width.
   [jone]
 

--- a/ftw/table/templates/basic.pt
+++ b/ftw/table/templates/basic.pt
@@ -8,7 +8,7 @@
         <tr>
             <tal:th tal:repeat="th view/columns">
                 <th tal:attributes="id python:view.get_thid(th);
-                                    class python:view.sortable_class(th['sort_index'])">
+                                    class python:view.sortable_class(th)">
                     <span tal:content="structure python: th['title']" tal:condition="th/title"/>
                 </th>
             </tal:th>

--- a/ftw/table/utils.py
+++ b/ftw/table/utils.py
@@ -208,7 +208,11 @@ class TableGenerator(object):
             value = content[attr]
         return transform(content, value)
 
-    def sortable_class(self, attr):
+    def sortable_class(self, col):
+        attr = col.get('sort_index')
+        if col.get('sortable') is False:
+            return None
+
         class_ = []
         if isinstance(self.sortable, (bool, int)):
             #if sortable is set to True, everything is sortable


### PR DESCRIPTION
At the moment the "sortable" option on the column definition has no influence in "html" (non-ExtJS) mode. This makes it nearly impossible to deactivate sorting on a specific column, at least when used in combination with `ftw.tabbedview`.

Therefore `sortable` on the column has no precedence when set to `False`.
