### PR TITLE
HTML style: support "width" of column definition as <col> width.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 1.12 (unreleased)
 -----------------
 
+- HTML style: support "width" of column definition as <col> width.
+  [jone]
+
 - ExtJS style: fix improper layout.
   Also show dummy column in table body using the same width used in the header.
   [Julian Infanger]

--- a/ftw/table/templates/basic.pt
+++ b/ftw/table/templates/basic.pt
@@ -1,7 +1,8 @@
 <table tal:attributes="class view/css_mapping/table">
     <colgroup>
         <col tal:repeat="th view/columns"
-             tal:attributes="class python:len(th['sort_index']) and 'col-'+th['sort_index'] or 'col'" />
+             tal:attributes="class python:len(th['sort_index']) and 'col-'+th['sort_index'] or 'col';
+                             width th/width|nothing" />
     </colgroup>
     <thead>
         <tr>


### PR DESCRIPTION
The `width` option in the column definition is already supported by the ExtJS style.
This adds the `width` value as `<col>` attribute so that it works in HTML style too.
