### PR TITLE
Fix regression from better "sortable" support (1.12)

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,14 @@ Changelog
 1.13 (unreleased)
 -----------------
 
-- Nothing changed yet.
+- Fix regression from better "sortable" support (1.12), which
+  resulted in AttributeErrors when having the table template
+  customized.
+
+  Use `view.sortable_class(th)` instead of `view.sortable_class(th['sort_index'])`
+  in custom table templates.
+
+  [jone]
 
 
 1.12 (2013-07-09)

--- a/ftw/table/utils.py
+++ b/ftw/table/utils.py
@@ -209,9 +209,16 @@ class TableGenerator(object):
         return transform(content, value)
 
     def sortable_class(self, col):
-        attr = col.get('sort_index')
-        if col.get('sortable') is False:
-            return None
+        if isinstance(col, dict):
+            # new style: it's a column
+            attr = col.get('sort_index')
+            if col.get('sortable') is False:
+                return None
+
+        else:
+            # old style: it's probably the sort_index
+            attr = col
+            col = None
 
         class_ = []
         if isinstance(self.sortable, (bool, int)):


### PR DESCRIPTION
Regression resulted in AttributeErrors when having the table template customized.
Use `view.sortable_class(th)` instead of `view.sortable_class(th['sort_index'])` in custom table templates.

This fixes issues such as:

``` python
....

  File "/Users/jone/projects/python/cache/eggs/zope.tales-3.5.3-py2.7.egg/zope/tales/tales.py", line 696, in evaluate
    return expression(self)
   - /Users/jone/projects/packages/ftw.contentpage/ftw/contentpage/browser/table-custom-template.pt
   - Line 10, Column 16
   - Expression: <PythonExpr ('%s %s' % (view.get_thid(th), view.sortable_class(th['sort_index'])))>
   - Names:
      {'args': (),
       'container': None,
       'context': None,
       'default': <object object at 0x10a9d7830>,
       'here': None,
       'loop': {},
       'nothing': None,
       'options': {},
       'repeat': <Products.PageTemplates.Expressions.SafeMapping object at 0x1121c3e68>,
       'request': <HTTPRequest, URL=http://nohost>,
       'root': None,
       'template': <Products.Five.browser.pagetemplatefile.ViewPageTemplateFile object at 0x11216e990>,
       'traverse_subpath': [],
       'user': <PloneUser 'test-user'>,
       'view': <ftw.table.utils.TableGenerator object at 0x110e8b310>,
       'views': <Products.Five.browser.pagetemplatefile.ViewMapper object at 0x11216ecd0>}
  File "/Users/jone/projects/python/cache/eggs/zope.tales-3.5.3-py2.7.egg/zope/tales/pythonexpr.py", line 59, in __call__
    return eval(self._code, vars)
   - __traceback_info__: ('%s %s' % (view.get_thid(th), view.sortable_class(th['sort_index'])))
  File "<string>", line 1, in <module>
  File "/Users/jone/projects/packages/ftw.contentpage/src/ftw.table/ftw/table/utils.py", line 212, in sortable_class
    attr = col.get('sort_index')
AttributeError: 'str' object has no attribute 'get'
```
