### PR TITLE
Fixes IE9 bug where content grows when hovering over dynamically generated content.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,9 @@ Changelog
 1.12.4 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Fixes IE9 bug where content grows when hovering over dynamically generated content.
+  See http://blog.brianrichards.net/post/6721471926/ie9-hover-bug-workaround for details
+  [Julian Infanger]
 
 
 1.12.3 (2013-10-16)

--- a/ftw/table/browser/extjs/ext-all.css
+++ b/ftw/table/browser/extjs/ext-all.css
@@ -366,11 +366,21 @@
 }
 /* @end */
 
+/* @group growing content bug IE9 */
+
+div.x-grid3-viewport {
+  min-height: 0%;
+}
+
+/* @end */
+
 /* @group ugly fixes */
+
 .x-grid3-td-dummy {
   width: 5px !important;
   display: table-cell !important;
   border: none !important;
   background-color: #FFFFFF;
 }
+
 /* @end */


### PR DESCRIPTION
See http://blog.brianrichards.net/post/6721471926/ie9-hover-bug-workaround for details

Thanks @lukasgraf for the hint!!!

@phgross this fixes the problem in IE 9
