### PR TITLE
Fix readable_date_text helper, if there is no valid date.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 1.14 (unreleased)
 -----------------
 
+- Fix readable_date_text helper, if there is no valid date like the init value
+  of a Archetype DateTimeField (EffectiveDate returns 1000/01/01).
+
 - Add English translations.
   [jone]
 

--- a/ftw/table/helper.py
+++ b/ftw/table/helper.py
@@ -182,10 +182,14 @@ def readable_date_text(item, date):
         return None
     if not getattr(date, 'strftime', None):
         return None
-    if date.strftime('%Y%m%d') == today:
-        strftimestring = 'heute'  # XXX i18n not working atm
-    elif date.strftime('%Y%m%d') == yesterday:
-        strftimestring = 'gestern'  # XXX i18n not working atm
+    try:
+        if date.strftime('%Y%m%d') == today:
+            strftimestring = 'heute'  # XXX i18n not working atm
+        elif date.strftime('%Y%m%d') == yesterday:
+            strftimestring = 'gestern'  # XXX i18n not working atm
+    except ValueError:
+        return None
+
     return date.strftime(strftimestring)
 
 

--- a/ftw/table/tests/test_helper_readable_date.py
+++ b/ftw/table/tests/test_helper_readable_date.py
@@ -46,6 +46,11 @@ class TestReadableDateTime(TestCase):
             '17.10.2012 20:08',
             readable_date_time(object, datetime(2012, 10, 17, 20, 8)))
 
+    def test_date_date_text_if_date_is_before_1900(self):
+        self.assertEqual(
+            None,
+            readable_date_time(object, datetime(1000, 1, 1, 0, 0)))
+
 
 class TestReadableDateTimeText(TestCase):
 


### PR DESCRIPTION
For example:
- Init value of an Archetype DateTimeField is 1000/01/01, which means kind of empty.
