### PR TITLE
Multiline comments causing minified ftwtable.extjs.js to be garbled

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,9 @@ Changelog
 1.14.2 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Replace multiline JS comments with single line ones to prevent minification
+  issues.
+  [lgraf]
 
 
 1.14.1 (2014-04-30)

--- a/ftw/table/browser/ftwtable.extjs.js
+++ b/ftw/table/browser/ftwtable.extjs.js
@@ -1,10 +1,10 @@
 Ext.Ajax.timeout = 120000;  // 2 minutes
 
-/* EXTJS overrides */
+// EXTJS overrides */
 
-/* These overrides are required to prevent the table from scrolling */
-/* on row selection due to focus change in the `mouseDown` event. */
-/* See https://github.com/4teamwork/ftw.table/issues/31 for details. */
+// These overrides are required to prevent the table from scrolling
+// on row selection due to focus change in the `mouseDown` event.
+// See https://github.com/4teamwork/ftw.table/issues/31 for details.
 
 Ext.override(Ext.grid.RowSelectionModel, {
     handleMouseDown : function(g, rowIndex, e){


### PR DESCRIPTION
The [multiline comments](https://github.com/4teamwork/ftw.table/pull/32/files#diff-5ed6b3580f1dd59efed5e412a88b3b34R3) introduced in https://github.com/4teamwork/ftw.table/pull/32 at the top of `ftwtable.extjs.js` seem to cause the minified version of the file to be screwed up:

`resourceftwtable.extjs-cachekey-eb5a4be5f1871762c8d31548f57690d1.js`:

``` javascript
/* - ++resource++ftwtable.extjs.js - */
// http://localhost:8080/Plone/portal_javascripts/++resource++ftwtable.extjs.js?original=1
Ext.Ajax.timeout=120000}else{var isSelected=this.isSelected(rowIndex);
```

 That first closing bracket `}` is invalid because it was never opened, and after `Ext.Ajax.timeout=120000` random stuff seems to have been dropped from the source JS.
