### PR TITLE
Add ftw.labels filtering support to catalog source.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 1.14.3 (unreleased)
 -------------------
 
+- Add ftw.labels filtering support to catalog source.
+  [jone]
+
 - Removed left over closing multiline comment from #33 in ftwtable.extjs.js.
   [lgraf]
 


### PR DESCRIPTION
`ftw.labels` has a filtering feature, adding `labels` to the tabbedview request (as tabbedview property).
This change merges the `labels` value into the catalog query.
It adds a dict of allowed indexes to normalizer / pre processors, allowing to easily add more such use cases and pre process the values using a callback before merging it into the query.

This adds support for `ftw.labels` to all catalog source based views, without further changes needed.

@maethu can you take a look at it?
