### PR TITLE
Fix ftwtable.extjs.js (missing semicolon).

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 1.14.3 (unreleased)
 -------------------
 
+- Fix ftwtable.extjs.js (missing semicolon).
+  [mathias.leimgruber]
+
 - Add ftw.labels filtering support to catalog source.
   [jone]
 

--- a/ftw/table/browser/ftwtable.extjs.js
+++ b/ftw/table/browser/ftwtable.extjs.js
@@ -30,7 +30,7 @@ Ext.override(Ext.grid.RowSelectionModel, {
         }
     },
 
-})
+});
 
 
 Ext.grid.FTWTableGroupingView = Ext.extend(Ext.grid.GroupingView, {


### PR DESCRIPTION
IE10 has Problems in some cases. 
