### PR TITLE
Fix encoding error in "linked" helper with solr flairs.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.15.1 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Fix encoding error in "linked" helper with solr flairs.
+  [jone]
 
 
 1.15.0 (2014-06-03)

--- a/ftw/table/helper.py
+++ b/ftw/table/helper.py
@@ -235,9 +235,11 @@ def linked(item, value, show_icon=True, attrs=None, icon_only=False):
         title = item.Title
         if callable(title):
             title = title()
+        if isinstance(title, str):
+            title = title.decode('utf-8')
 
         img = u'<img src="%s/%s" alt="%s"/>' % (
-            portal_url(), icon, title.decode('utf8'))
+            portal_url(), icon, title)
         if not icon:
             attrs['class'].append(
                 'contenttype-%s' %

--- a/ftw/table/tests/test_helper_linked.py
+++ b/ftw/table/tests/test_helper_linked.py
@@ -1,3 +1,4 @@
+from collections import namedtuple
 from ftw.builder import Builder
 from ftw.builder import create
 from ftw.table.helper import linked
@@ -11,6 +12,10 @@ from plone.app.testing import TEST_USER_NAME
 from Products.CMFCore.Expression import Expression
 from Products.CMFCore.utils import getToolByName
 from unittest2 import TestCase
+
+
+SolrFlairMock = namedtuple('Flair',
+                           ('Title', 'getIcon', 'portal_type'))
 
 
 class TestLinkedWithIcon(TestCase):
@@ -74,6 +79,14 @@ class TestLinkedWithIcon(TestCase):
         self.assertEqual(
             self.folder.Title(),
             element.text_content())
+
+    def test_linked_with_unicode_title(self):
+        # Solr flairs sometimes have unicode metadata..
+        flair = SolrFlairMock(Title=u'\xf6rdnerli',
+                              getIcon=u'file.png',
+                              portal_type=u'File')
+        self.assertIn(u'alt="\xf6rdnerli"',
+                      linked(flair, flair.Title))
 
 
 class TestLinkedWithoutIcon(TestCase):


### PR DESCRIPTION
Solr sometimes uses `unicode` in it's flair metadata, although the catalog uses `str`.
This PR fixes the `linked` helper to also support `Title` to be `unicode`.

/ @maethu 
