### PR TITLE
Flush `groupBy` params during the table destroy, to avoid invalid groupBy values

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,9 @@ Changelog
 1.15.3 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Flush `groupBy` params during the table destroy, to avoid invalid
+  groupBy values.
+  [phgross]
 
 
 1.15.2 (2014-10-24)

--- a/ftw/table/browser/ftwtable.extjs.js
+++ b/ftw/table/browser/ftwtable.extjs.js
@@ -507,6 +507,10 @@ Ext.state.FTWPersistentProvider = Ext.extend(Ext.state.Provider, {
   };
 
   $.fn.ftwtable.destroy = function(){
+    if(typeof(tabbedview) != "undefined") {
+      tabbedview.flush_params('groupBy');
+    }
+    Ext.state.Manager.clear(stateName());
     if(grid && grid.boxReady){
       grid.destroy();
     }


### PR DESCRIPTION
Fixes a `RuntimeError` that happens when using grouping functionality. See https://github.com/4teamwork/opengever.core/issues/531 for more details.

The bug can be reproduced as follows:
 - Group by a column, change tab, change back to previous tab, group by a column.

 or

 - Group by a column, disable grouping, change tab, change back to previous tab, group by a column.

@jone