### PR TITLE
Use plones IContentIcon adapter when available.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 1.15.3 (unreleased)
 -------------------
 
+- Use plones IContentIcon adapter when available.
+  [jone]
+
 - Flush `groupBy` params during the table destroy, to avoid invalid
   groupBy values.
   [phgross]


### PR DESCRIPTION
Changes the helper to use Plone's IContentIcon helper instead of getIcon
directly.
This allows us to change the behavior by overwriting the adapters, for
example for replacing mimetype icons with font-icons or sprites.

This may not work on older Plone sites and it does not work when the
item is a Solr flair. In those cases we fallback to the old
implementation.

/cc @4teamwork/gever 