### PR TITLE
Introduce viewready event.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.16.1 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Expose `viewReady` event to DOM.
+  [Kevin Bieri]
 
 
 1.16.0 (2015-10-19)

--- a/ftw/table/browser/ftwtable.extjs.js
+++ b/ftw/table/browser/ftwtable.extjs.js
@@ -370,6 +370,8 @@ Ext.state.FTWPersistentProvider = Ext.extend(Ext.state.Provider, {
                 if(typeof(tabbedview) != "undefined") {
                   tabbedview.hide_spinner();
                 }
+
+                $this.trigger('viewReady');
               },
 
               afterrender: function(panel){


### PR DESCRIPTION
We habe to expose this event because after the `afterrender` event
the table is not yet loaded.
So the table does not contain any elements.