### PR TITLE
Drop Plone 4.1 support.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.17.1 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Drop Plone 4.1 support. [jone]
 
 
 1.17.0 (2016-06-27)

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,6 @@ setup(name='ftw.table',
       classifiers=[
           'Framework :: Plone',
           'Framework :: Plone :: 4.0',
-          'Framework :: Plone :: 4.1',
           'Framework :: Plone :: 4.2',
           'Framework :: Plone :: 4.3',
           'Programming Language :: Python',

--- a/test-plone-4.1.x.cfg
+++ b/test-plone-4.1.x.cfg
@@ -1,6 +1,0 @@
-[buildout]
-extends =
-    https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-4.1.x.cfg
-    sources.cfg
-
-package-name = ftw.table


### PR DESCRIPTION
Tests are failing, we are no longer supporting Plone 4.1.