### PR TITLE
Use absolute urls to set and reset the grid-state.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,12 @@ Changelog
 1.18.1 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Use absolute urls to set and reset the grid-state to fix an issue if
+  using the table on a non-folderish content in plone. Plone does not add a
+  trailing slash in the html base-tag for non-folderish content. This means,
+  relative urls will resolve to the parent object.
+  [elioschmutz]
+
 
 
 1.18.0 (2017-03-16)

--- a/ftw/table/browser/ftwtable.extjs.js
+++ b/ftw/table/browser/ftwtable.extjs.js
@@ -1,5 +1,15 @@
 Ext.Ajax.timeout = 120000;  // 2 minutes
 
+//Use absolute urls to set and reset the grid-state to fix an issue if
+//using the table on a non-folderish content in plone. Plone does not add a
+//trailing slash in the html base-tag for non-folderish content. This means,
+//relative urls will resolve to the parent object.
+Ext.state.gridStateEndPoint = function() {
+  var absoluteURL = location.href.split(/\?|#/)[0];  // get absolute url without params and hashes
+  absoluteURL = absoluteURL.replace(/\/$/, "");  // remove trailing slash
+  return absoluteURL + "/@@tabbed_view/setgridstate";
+}();
+
 // EXTJS overrides
 
 // These overrides are required to prevent the table from scrolling
@@ -71,7 +81,7 @@ Ext.grid.FTWTableGroupingView = Ext.extend(Ext.grid.GroupingView, {
 
 function reset_grid_state() {
   $.ajax({
-    url: '@@tabbed_view/setgridstate',
+    url: Ext.state.gridStateEndPoint,
     cache: false,
     type: "POST",
     data: {
@@ -94,7 +104,7 @@ Ext.state.FTWPersistentProvider = Ext.extend(Ext.state.Provider, {
   set : function(name, value){
     Ext.state.FTWPersistentProvider.superclass.set.call(this, name, value);
     $.ajax({
-      url: '@@tabbed_view/setgridstate',
+      url: Ext.state.gridStateEndPoint,
       cache: false,
       type: "POST",
       data: {


### PR DESCRIPTION
Use absolute urls for set and reset the grid-state to fix an issue if using the table on a non-folderish content in plone.

Explanation:

The BASE-Tag defines the default url for the current page and defines the base for relative links. See https://www.w3schools.com/tags/tag_base.asp for more information.

If the basetag ends with a trailing slash, the resource will be handled as "folderish". I.e.:

`<base href="http://foo/bar/" />`

`<a href="john"></>` => resolves to `http://foo/bar/john`

If the basetag ends without a trailing slash, the resource will be handled as "non-folderish". I.e.:

`<base href="http://foo/bar.html" />`

`<a href="john"></>` => resolves to `http://foo/john`

In plone, a folderish contenttype will end with a trailing slash, a non-folderish contenttype will end without a trailing slash. This behavior is correct. But we get some problems:

Relative links within a view of a non-folderish contenttype will resolve to its parent object. Also submitting ajaxrequests will call the parent object instead the current context:

Request on a folderish context:

![bildschirmfoto 2017-04-20 um 16 13 22](https://cloud.githubusercontent.com/assets/557005/25235059/5153769c-25e4-11e7-8669-836624badc10.png)

Request on a non-folderish context will call its parent url:

![bildschirmfoto 2017-04-20 um 16 12 52](https://cloud.githubusercontent.com/assets/557005/25235074/5b454a04-25e4-11e7-81c0-3007ce16e11c.png)

Both requests are submitted to `/ein-folder` because the base-tag. So setting the current grid-state on a non-foderish wont be possible.