### PR TITLE
Remove dependency on ftw.testing[splinter]

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.18.2 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Remove dependency on ftw.testing[splinter] (has been dropped in ftw.testing). [lgraf]
 
 
 1.18.1 (2017-04-24)

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ maintainer = 'Jonas Baumann'
 tests_require = [
     'collective.js.extjs',
     'ftw.builder',
-    'ftw.testing [splinter]',
+    'ftw.testing',
     'plone.app.testing',
     'plone.mocktestcase',
     ]


### PR DESCRIPTION
This removes the dependency on the `ftw.testing[splinter]` extra, which has been [dropped from 
`ftw.testing`](https://github.com/4teamwork/ftw.testing/commit/6eadb49bed08a0b40113d65abf8b302935cb1007).