### PR TITLE
Allow registering extjs static-containers based on classes instead only for ids to prevent duplicated ids in html

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,8 @@ Changelog
 1.18.2 (unreleased)
 -------------------
 
+- Allow registering extjs static-containers based on classes instead only for ids to prevent duplicated ids in html [elioschmutz]
+
 - Remove dependency on ftw.testing[splinter] (has been dropped in ftw.testing). [lgraf]
 
 

--- a/ftw/table/browser/ftwtable.extjs.js
+++ b/ftw/table/browser/ftwtable.extjs.js
@@ -402,7 +402,16 @@ Ext.state.FTWPersistentProvider = Ext.extend(Ext.state.Provider, {
                 */
                 if(store.reader.meta['static'] != undefined){
                   $.each(store.reader.meta['static'], function(key, value) {
-                    $('#'+key+'_container.ftwtable').html(value);
+
+                    // We check for a container based on IDs
+                    var static_container = $('#'+key+'_container.ftwtable');
+
+                    // If there is no container, we check for a container registered
+                    // based on a class.
+                    if (static_container.length <= 0) {
+                      static_container = $('.'+key+'Container.ftwtable');
+                    }
+                    static_container.html(value);
                   });
                 }
                 options.onLoad();


### PR DESCRIPTION
Sometimes we need static elements multiple times per page (i.e. a batching container).

To do this, the static-implementation have to respect class-based-elements too.

This PR allows registering extjs static-containers based on classes instead only for ids to prevent duplicated ids in html.

Issuer: https://github.com/4teamwork/opengever.core/pull/3217