### PR TITLE
Fix concurrency bug in generator: data was leaking between threads.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,8 +5,7 @@ Changelog
 1.19.2 (unreleased)
 -------------------
 
-- Nothing changed yet.
-
+- Fix concurrency bug in generator: data was leaking between threads. [jone]
 
 1.19.1 (2018-04-04)
 -------------------

--- a/ftw/table/configure.zcml
+++ b/ftw/table/configure.zcml
@@ -15,7 +15,7 @@
     <i18n:registerTranslations directory="locales" />
 
     <utility name="ftw.tablegenerator"
-             factory=".utils.TableGenerator"
+             factory=".utils.TableGeneratorSingleton"
              provides=".interfaces.ITableGenerator"
              />
 

--- a/ftw/table/utils.py
+++ b/ftw/table/utils.py
@@ -19,6 +19,18 @@ except ImportError:
     from zope.app.component import hooks
 
 
+class TableGeneratorSingleton(object):
+    """When registering a utility as factory, the factory is called on ZCML parse time
+    and returns a singleton object which is kept.
+    Because our TableGenerator relies on state and is not thread safe, the table generator
+    singleton instantiates a new object for each generate method call, so that we can
+    fix this problem without reimplementing the generator completely.
+    """
+
+    def generate(self, *args, **kwargs):
+        return TableGenerator().generate(*args, **kwargs)
+
+
 class TableGenerator(object):
     """ generates a html table. See README.txt for usage"""
 


### PR DESCRIPTION
When registering a utility as factory, the factory is called on ZCML parse time and returns a singleton object which is kept. When the generator utility was built, we relied on the factory beeing called on utility lookup time, but this is not how it works.

Using the same object for multiple "generate" calls has side effects, especially when used concurrently in multiple threads.

Since the generator utility is used in many places in our code base, we decided to not change the public facing API but solve the problem internally by using a real singleton object, which delegates "generate" calls through freshly instantiated table generator objects.

We couldn't change the table generator's generate method to be static, because it uses the view page template, which relies on object state.

Fixes https://github.com/4teamwork/opengever.core/issues/4783