### PR TITLE
Refactor TableGenerator to make it thread-safe

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 1.19.2 (unreleased)
 -------------------
 
+- Refactor TableGenerator to make it thread safe. [njohner]
 - Fix concurrency bug in generator: data was leaking between threads. [jone]
 
 1.19.1 (2018-04-04)

--- a/ftw/table/configure.zcml
+++ b/ftw/table/configure.zcml
@@ -15,7 +15,7 @@
     <i18n:registerTranslations directory="locales" />
 
     <utility name="ftw.tablegenerator"
-             factory=".utils.TableGeneratorSingleton"
+             factory=".utils.TableGenerator"
              provides=".interfaces.ITableGenerator"
              />
 

--- a/ftw/table/interfaces.py
+++ b/ftw/table/interfaces.py
@@ -7,8 +7,24 @@ from zope import schema
 
 
 class ITableGenerator(Interface):
-    """generates html tables.
+    """generates tables.
+
+    Careful when handling the TableGenerator, as this is registered as
+    a utility factory, which is called on ZCML parse time. Hence there is
+    a single instance of this Object, which can be shared between threads.
+    The exposed methods are thread-safe, but others might not be.
     """
+
+    def generate(self, contents, columns, sortable=False,
+                 selected=(None, None), css_mapping={}, translations=[],
+                 template=None, options={}, output='html', meta_data=None):
+        """Generate the table either in html (default) or json format (output='json')
+        """
+
+    def process_columns(self, columns):
+        """Process the columns to standardise their format (dictionnaries)
+        and attributes.
+        """
 
 
 class ITableSource(Interface):


### PR DESCRIPTION
This PR is a followup to https://github.com/4teamwork/ftw.table/pull/49, where we resolved a concurrency bug in `TableGenerator` for issue 4teamwork/opengever.core#4783. The Fix in https://github.com/4teamwork/ftw.table/pull/49 did not cover all the use cases in our code-base, so we propose a more complete and cleaner solution here.

`generate` is not the only method from TableGenerator that gets used, so we need to give access to its other attributes, notably `process_columns`. We therefore override `__getattr__`

Note that `__getattr__` only gets called when an attribute of a given name is not found on the current object, hence it is still possible to easily override any attribute of `TableGeneratorSingleton` by subclassing.