### PR TITLE
Add level as a configurable query parametre

### DIFF
--- a/ftw/table/catalog_source.py
+++ b/ftw/table/catalog_source.py
@@ -52,6 +52,7 @@ class DefaultCatalogTableSourceConfig(BaseTableSourceConfig):
 
     implements(ICatalogTableSourceConfig)
 
+    level = 0
     depth = -1
     types = []
     object_provides = None
@@ -79,6 +80,7 @@ class DefaultCatalogTableSourceConfig(BaseTableSourceConfig):
         # extend with path filter, if configured
         if 'path' not in query and getattr(self, 'filter_path', None):
             query['path'] = {'query': self.filter_path,
+                             'level': self.level,
                              'depth': self.depth}
 
         # extend with types

--- a/ftw/table/interfaces.py
+++ b/ftw/table/interfaces.py
@@ -153,6 +153,14 @@ class ICatalogTableSourceConfig(ITableSourceConfig):
         'the `depth` attribute.',
         default=None)
 
+    level = schema.Int(
+        title=u'Recursivity start level',
+        description=u'Defines the search start level. If it set to 0 '
+        u'(default) the current context is included. If set to 1, it will '
+        u'only find objects starting from the children of the current '
+        u'context.',
+        default=0)
+
     depth = schema.Int(
         title=u'Recursivity depth',
         description=u'Defines the recursivity depth, how depth the contents '


### PR DESCRIPTION
As we already can configure the extended path index depth parametre, we should also include support for configuring the level parametre.

https://github.com/plone/Products.ExtendedPathIndex/blob/6269514e210c24f9e043bc8a6d6805d80f2fde0d/Products/ExtendedPathIndex/ExtendedPathIndex.py#L189