### PR TITLE
Add a feature to exclude exact path matches from search results

### DIFF
--- a/ftw/table/basesource.py
+++ b/ftw/table/basesource.py
@@ -12,6 +12,7 @@ class BaseTableSourceConfig(object):
     sort_on = 'sortable_title'
     sort_reverse = False
     filter_text = ''
+    include_searchroot = False
     batching_enabled = False
     batching_pagesize = None
     batching_current_page = 1

--- a/ftw/table/interfaces.py
+++ b/ftw/table/interfaces.py
@@ -104,6 +104,11 @@ class ITableSourceConfig(Interface):
         description=u'Text which is used for filtering the elements. '
         'Dependening on the source there may also be a index defined.')
 
+    include_searchroot = schema.Bool(
+        title=u'Include the object at the exact search path from the results',
+        description=u'If `True` the object at the exact search path is '
+        u'included in the results.')
+
     batching_enabled = schema.Bool(
         title=u'Batching is enabled',
         description=u'`True` if batching is enabled. This is used for '


### PR DESCRIPTION
Motivation: in quite many `opengever.core` `ftw.tabbedview` listings it makes little sense to also display the container itself.

Case example: subdossier tabs on deeper nested thin subdossier hierarchies.