### PR TITLE
CatalogTableSource: Exclude searchroot from results

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.20.1 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- CatalogTableSource: Exclude searchroot from results. [lgraf]
 
 
 1.20.0 (2018-08-28)

--- a/ftw/table/basesource.py
+++ b/ftw/table/basesource.py
@@ -12,6 +12,7 @@ class BaseTableSourceConfig(object):
     sort_on = 'sortable_title'
     sort_reverse = False
     filter_text = ''
+    exclude_searchroot = True
     batching_enabled = False
     batching_pagesize = None
     batching_current_page = 1

--- a/ftw/table/interfaces.py
+++ b/ftw/table/interfaces.py
@@ -104,6 +104,13 @@ class ITableSourceConfig(Interface):
         description=u'Text which is used for filtering the elements. '
         'Dependening on the source there may also be a index defined.')
 
+    exclude_searchroot = schema.Bool(
+        title=u'Exclude the object at the exact search path from the results',
+        description=u"If `True` the object at the exact search path is "
+        u"omitted from the results (doesn't apply to path queries with "
+        u"depth 0 or 1).",
+        default=True)
+
     batching_enabled = schema.Bool(
         title=u'Batching is enabled',
         description=u'`True` if batching is enabled. This is used for '


### PR DESCRIPTION
By default, the CatalogTableSource will now take care to **not include the searchroot** itself in the results.

This fixes a bug where otherwise for listings on containers the folderish context itself was included in the list of its children.

This behavior is enabled by default, but can be turned of by setting `config.exclude_searchroot = False`. (For path queries of depth `0` or `1` it has no effect either way).

Omitting the searchroot from the results is achieved by transforming the query:

A path query against a specific context will be transformed into a multi-path query against all that context's immediate children (which are determined beforehand via a second query).

This will cause the transformed query to return the exact same results, except that the context queried against (the searchroot) now isn't included in the results.

Supersedes #52 *(I'm opening a new PR to preserve the discussion in #52 and not clutter that PR)*

Also see:
4teamwork/opengever.core#4851
4teamwork/opengever.core#4888